### PR TITLE
Optimize frontend performance with code splitting and lazy loading

### DIFF
--- a/oid-portal/src/App.jsx
+++ b/oid-portal/src/App.jsx
@@ -1,22 +1,26 @@
 import { BrowserRouter as Router, Routes, Route } from './lib/router';
 import Layout from './components/Layout';
-import Home from './pages/Home';
-import RegisterBadge from './pages/RegisterBadge';
-import EditBadge from './pages/EditBadge';
-import OidTree from './pages/OidTree';
-import ChatAssistant from './pages/ChatAssistant';
+import { Suspense, lazy } from 'react';
+
+const Home = lazy(() => import('./pages/Home'));
+const RegisterBadge = lazy(() => import('./pages/RegisterBadge'));
+const EditBadge = lazy(() => import('./pages/EditBadge'));
+const OidTree = lazy(() => import('./pages/OidTree'));
+const ChatAssistant = lazy(() => import('./pages/ChatAssistant'));
 
 function App() {
   return (
     <Router>
       <Layout>
-        <Routes>
-          <Route path="/" element={<Home />} />
-          <Route path="/register" element={<RegisterBadge />} />
-          <Route path="/edit/:oid" element={<EditBadge />} />
-          <Route path="/oid-tree" element={<OidTree />} />
-          <Route path="/chat" element={<ChatAssistant />} />
-        </Routes>
+        <Suspense fallback={<div>Loading...</div>}>
+          <Routes>
+            <Route path="/" element={<Home />} />
+            <Route path="/register" element={<RegisterBadge />} />
+            <Route path="/edit/:oid" element={<EditBadge />} />
+            <Route path="/oid-tree" element={<OidTree />} />
+            <Route path="/chat" element={<ChatAssistant />} />
+          </Routes>
+        </Suspense>
       </Layout>
     </Router>
   );

--- a/oid-portal/src/pages/ChatAssistant.jsx
+++ b/oid-portal/src/pages/ChatAssistant.jsx
@@ -218,11 +218,11 @@ To learn more about a specific aspect of the system, could you provide more deta
       <div className="mt-2 p-2 bg-darker-bg rounded-md flex items-center">
         <div className="p-2 rounded-md bg-content-bg mr-2">
           {isImage ? (
-            <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 text-primary" viewBox="0 0 20 20" fill="currentColor">
+            <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 text-primary" viewBox="0 0 20 20" fill="currentColor" loading="lazy">
               <path fillRule="evenodd" d="M4 3a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V5a2 2 0 00-2-2H4zm12 12H4l4-8 3 6 2-4 3 6z" clipRule="evenodd" />
             </svg>
           ) : (
-            <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 text-primary" viewBox="0 0 20 20" fill="currentColor">
+            <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 text-primary" viewBox="0 0 20 20" fill="currentColor" loading="lazy">
               <path fillRule="evenodd" d="M4 4a2 2 0 012-2h4.586A2 2 0 0112 2.586L15.414 6A2 2 0 0116 7.414V16a2 2 0 01-2 2H6a2 2 0 01-2-2V4z" clipRule="evenodd" />
             </svg>
           )}
@@ -249,7 +249,7 @@ To learn more about a specific aspect of the system, could you provide more deta
           <div className="p-4 border-b border-border-color">
             <div className="flex items-center">
               <div className="flex-shrink-0 h-10 w-10 rounded-full bg-primary flex items-center justify-center">
-                <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6 text-text-primary" viewBox="0 0 20 20" fill="currentColor">
+                <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6 text-text-primary" viewBox="0 0 20 20" fill="currentColor" loading="lazy">
                   <path fillRule="evenodd" d="M10 9a3 3 0 100-6 3 3 0 000 6zm-7 9a7 7 0 1114 0H3z" clipRule="evenodd" />
                 </svg>
               </div>
@@ -316,7 +316,7 @@ To learn more about a specific aspect of the system, could you provide more deta
                   onClick={handleAttachFile}
                   className="p-2 rounded-full text-text-secondary hover:text-primary focus:outline-none"
                 >
-                  <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+                  <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor" loading="lazy">
                     <path fillRule="evenodd" d="M8 4a3 3 0 00-3 3v4a5 5 0 0010 0V7a1 1 0 112 0v4a7 7 0 11-14 0V7a5 5 0 0110 0v4a3 3 0 11-6 0V7a1 1 0 012 0v4a1 1 0 102 0V7a3 3 0 00-3-3z" clipRule="evenodd" />
                   </svg>
                 </button>
@@ -326,7 +326,7 @@ To learn more about a specific aspect of the system, could you provide more deta
                   className="p-2 rounded-full text-primary hover:text-primary-light focus:outline-none"
                   disabled={!inputValue.trim()}
                 >
-                  <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+                  <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor" loading="lazy">
                     <path d="M10.894 2.553a1 1 0 00-1.788 0l-7 14a1 1 0 001.169 1.409l5-1.429A1 1 0 009 15.571V11h2a1 1 0 00.9-.553l4-8a1 1 0 00-.9-1.447h-7.118l2.112-2.224a1 1 0 00-.12-1.493L4.654 2.749a1 1 0 00-1.253.18L.01 7.061a1 1 0 00.098 1.266l2.4 2.4A1 1 0 003.5 10H8v5.571l-6.5 1.857a1 1 0 00-.59 1.545l3.71 3.71a1 1 0 001.415-1.42l-2.299-2.3 6.5-1.857a1 1 0 00.713-.954V10h6.182a1 1 0 00.894-.553l3-6A1 1 0 0017 2h-6.106z" />
                   </svg>
                 </button>
@@ -365,7 +365,7 @@ To learn more about a specific aspect of the system, could you provide more deta
             <div className="p-4">
               <div className="text-center mb-6">
                 <div className="mx-auto h-16 w-16 rounded-full bg-primary flex items-center justify-center">
-                  <svg xmlns="http://www.w3.org/2000/svg" className="h-8 w-8 text-text-primary" viewBox="0 0 20 20" fill="currentColor">
+                  <svg xmlns="http://www.w3.org/2000/svg" className="h-8 w-8 text-text-primary" viewBox="0 0 20 20" fill="currentColor" loading="lazy">
                     <path fillRule="evenodd" d="M10 9a3 3 0 100-6 3 3 0 000 6zm-7 9a7 7 0 1114 0H3z" clipRule="evenodd" />
                   </svg>
                 </div>

--- a/oid-portal/src/pages/ChatAssistant.jsx
+++ b/oid-portal/src/pages/ChatAssistant.jsx
@@ -218,7 +218,7 @@ To learn more about a specific aspect of the system, could you provide more deta
       <div className="mt-2 p-2 bg-darker-bg rounded-md flex items-center">
         <div className="p-2 rounded-md bg-content-bg mr-2">
           {isImage ? (
-            <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 text-primary" viewBox="0 0 20 20" fill="currentColor" loading="lazy">
+            <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 text-primary" viewBox="0 0 20 20" fill="currentColor">
               <path fillRule="evenodd" d="M4 3a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V5a2 2 0 00-2-2H4zm12 12H4l4-8 3 6 2-4 3 6z" clipRule="evenodd" />
             </svg>
           ) : (

--- a/oid-portal/src/pages/OidTree.jsx
+++ b/oid-portal/src/pages/OidTree.jsx
@@ -184,7 +184,7 @@ const OidTree = () => {
               className="w-5 h-5 mr-2 flex items-center justify-center text-text-secondary hover:text-text-primary"
             >
               {isExpanded ? (
-                <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor" loading="lazy">
+                <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
                   <path fillRule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clipRule="evenodd" />
                 </svg>
               ) : (

--- a/oid-portal/src/pages/OidTree.jsx
+++ b/oid-portal/src/pages/OidTree.jsx
@@ -184,11 +184,11 @@ const OidTree = () => {
               className="w-5 h-5 mr-2 flex items-center justify-center text-text-secondary hover:text-text-primary"
             >
               {isExpanded ? (
-                <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+                <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor" loading="lazy">
                   <path fillRule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clipRule="evenodd" />
                 </svg>
               ) : (
-                <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+                <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor" loading="lazy">
                   <path fillRule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clipRule="evenodd" />
                 </svg>
               )}
@@ -262,7 +262,7 @@ const OidTree = () => {
                     onChange={(e) => setSearchQuery(e.target.value)}
                   />
                   <div className="absolute inset-y-0 left-0 flex items-center pl-2">
-                    <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 text-text-secondary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 text-text-secondary" fill="none" viewBox="0 0 24 24" stroke="currentColor" loading="lazy">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
                     </svg>
                   </div>
@@ -355,7 +355,7 @@ const OidTree = () => {
             ) : (
               <div className="p-6 flex flex-col items-center justify-center text-center">
                 <div className="rounded-full bg-darker-bg p-3 mb-3">
-                  <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6 text-text-secondary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6 text-text-secondary" fill="none" viewBox="0 0 24 24" stroke="currentColor" loading="lazy">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
                   </svg>
                 </div>


### PR DESCRIPTION
Implement code splitting and lazy loading for React components and images.

* **Code Splitting and Lazy Loading for React Components**
  - Modify `oid-portal/src/App.jsx` to use `React.lazy` and `Suspense` for `Home`, `RegisterBadge`, `EditBadge`, `OidTree`, and `ChatAssistant` components.

* **Lazy Loading for Images**
  - Add `loading="lazy"` attribute to SVG elements in `oid-portal/src/pages/OidTree.jsx`.
  - Add `loading="lazy"` attribute to SVG elements in `oid-portal/src/pages/ChatAssistant.jsx`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Fadil369/brainSAIT-oid-system/pull/4?shareId=6d3704c8-eca2-4c83-80f5-e2932687d96f).