### PR TITLE
Clarify production delivery secret validation

### DIFF
--- a/.github/workflows/deploy-oid-worker.yml
+++ b/.github/workflows/deploy-oid-worker.yml
@@ -142,7 +142,7 @@ jobs:
         env:
           ADMIN_TOKEN: ${{ secrets.DELIVERY_ADMIN_TOKEN }}
         run: |
-          test -n "$ADMIN_TOKEN" || { echo "::error::ADMIN_TOKEN is not configured"; exit 1; }
+          test -n "$ADMIN_TOKEN" || { echo "::error::DELIVERY_ADMIN_TOKEN is not configured"; exit 1; }
 
       - name: Install zip utility
         run: sudo apt-get install -y zip

--- a/.github/workflows/deploy-oid-worker.yml
+++ b/.github/workflows/deploy-oid-worker.yml
@@ -140,9 +140,9 @@ jobs:
 
       - name: Validate upload secret
         env:
-          ADMIN_TOKEN: ${{ secrets.DELIVERY_ADMIN_TOKEN }}
+          DELIVERY_ADMIN_TOKEN: ${{ secrets.DELIVERY_ADMIN_TOKEN }}
         run: |
-          test -n "$ADMIN_TOKEN" || { echo "::error::DELIVERY_ADMIN_TOKEN is not configured"; exit 1; }
+          test -n "$DELIVERY_ADMIN_TOKEN" || { echo "::error::DELIVERY_ADMIN_TOKEN is not configured"; exit 1; }
 
       - name: Install zip utility
         run: sudo apt-get install -y zip


### PR DESCRIPTION
Use the actual GitHub secret name in the asset-upload preflight error. Wrangler remains pinned to the newest available release; its remaining advisories are confined to development tooling and have no fixed upstream release.