### PR TITLE
Pin fulfillment commands to the Worker config

### DIFF
--- a/workers/oid-order-fulfillment/package.json
+++ b/workers/oid-order-fulfillment/package.json
@@ -4,10 +4,10 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "wrangler dev",
-    "deploy": "wrangler deploy",
+    "dev": "wrangler dev --config wrangler.toml",
+    "deploy": "wrangler deploy --config wrangler.toml",
     "test": "node --test",
-    "tail": "wrangler tail"
+    "tail": "wrangler tail --config wrangler.toml"
   },
   "devDependencies": {
     "wrangler": "4.119.0"


### PR DESCRIPTION
Explicitly pass wrangler.toml for development, deployment, and tailing so ancestor or global Wrangler configs cannot redirect production commands to another Worker.