### PR TITLE
Gate credentialed production deployments

### DIFF
--- a/.github/workflows/deploy-oid-worker.yml
+++ b/.github/workflows/deploy-oid-worker.yml
@@ -65,10 +65,13 @@ jobs:
     environment: production
     if: >-
       ${{
-        (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-        (github.event_name == 'workflow_dispatch' &&
-         github.ref == 'refs/heads/main' &&
-         github.event.inputs.deploy_worker != 'false')
+        vars.PRODUCTION_DEPLOY_ENABLED == 'true' &&
+        (
+          (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+          (github.event_name == 'workflow_dispatch' &&
+           github.ref == 'refs/heads/main' &&
+           github.event.inputs.deploy_worker != 'false')
+        )
       }}
 
     steps:
@@ -127,10 +130,13 @@ jobs:
     environment: production
     if: >-
       ${{
-        (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-        (github.event_name == 'workflow_dispatch' &&
-         github.ref == 'refs/heads/main' &&
-         github.event.inputs.upload_assets != 'false')
+        vars.PRODUCTION_DEPLOY_ENABLED == 'true' &&
+        (
+          (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+          (github.event_name == 'workflow_dispatch' &&
+           github.ref == 'refs/heads/main' &&
+           github.event.inputs.upload_assets != 'false')
+        )
       }}
     needs: validate-worker
 

--- a/workers/oid-order-fulfillment/SETUP.md
+++ b/workers/oid-order-fulfillment/SETUP.md
@@ -39,6 +39,10 @@ The GitHub `production` environment must contain:
 
 Protect the environment with required reviewers. The deployment workflow accepts production pushes and manual dispatches only from `main`.
 
+Set the repository variable `PRODUCTION_DEPLOY_ENABLED=true` only after all
+production environment secrets are configured. Keep it `false` when
+deployments are performed directly from protected infrastructure.
+
 ## Deploy
 
 ```bash


### PR DESCRIPTION
Keep Worker validation active on every relevant change, but require the PRODUCTION_DEPLOY_ENABLED repository variable before running protected deploy and asset-upload jobs.