### PR TITLE
fix: map live Shopify BSP-OID-* SKUs to fulfillment asset manifests

### DIFF
--- a/workers/oid-order-fulfillment/src/index.js
+++ b/workers/oid-order-fulfillment/src/index.js
@@ -120,10 +120,10 @@ const SKU_ASSETS = {
 // underlying asset manifest (e.g. the live Shopify catalog sells "BSP-OID-*" SKUs while this
 // manifest was originally keyed by the internal "OID-*-001" naming). Alias them here instead of
 // duplicating manifests, so a rename on either side only needs one line changed.
-SKU_ASSETS["BSP-OID-INTEGRATION-BLUEPRINT"] = SKU_ASSETS["OID-STARTER-001"];
-SKU_ASSETS["BSP-OID-REGISTRY-PLATFORM"] = SKU_ASSETS["OID-DEV-001"];
-SKU_ASSETS["BSP-OID-NPHIES-BUNDLE"] = SKU_ASSETS["OID-HLTH-001"];
-SKU_ASSETS["BSP-OID-ENTERPRISE-BADGE"] = SKU_ASSETS["OID-BADGE-001"];
+SKU_ASSETS["BSP-OID-INTEGRATION-BLUEPRINT"] = { ...SKU_ASSETS["OID-STARTER-001"], assets: [...SKU_ASSETS["OID-STARTER-001"].assets] };
+SKU_ASSETS["BSP-OID-REGISTRY-PLATFORM"] = { ...SKU_ASSETS["OID-DEV-001"], assets: [...SKU_ASSETS["OID-DEV-001"].assets] };
+SKU_ASSETS["BSP-OID-NPHIES-BUNDLE"] = { ...SKU_ASSETS["OID-HLTH-001"], assets: [...SKU_ASSETS["OID-HLTH-001"].assets] };
+SKU_ASSETS["BSP-OID-ENTERPRISE-BADGE"] = { ...SKU_ASSETS["OID-BADGE-001"], assets: [...SKU_ASSETS["OID-BADGE-001"].assets] };
 
 async function generateLicenseKey(secret, orderId, lineItemId, unit, sku) {
   const prefix = sku.replace(/[^A-Z0-9]/g, "").slice(0, 8);

--- a/workers/oid-order-fulfillment/src/index.js
+++ b/workers/oid-order-fulfillment/src/index.js
@@ -106,7 +106,24 @@ const SKU_ASSETS = {
       { id: "fhir-plat-docs", r2_key: "products/oid-fhir-platform/fhir-platform-docs.html", filename: "FHIR_Platform_Docs.html", kind: "html", size: 0 },
     ],
   },
+  "BSP-OID-ARDUINO-SCANNER": {
+    name: "OID Arduino IoT Scanner — Hardware Blueprint",
+    maxDownloads: 5,
+    expiresInDays: 365,
+    assets: [
+      { id: "arduino-notice", r2_key: "products/oid-arduino/arduino-scanner-notice.html", filename: "Order_Confirmation_and_Delivery_Notice.html", kind: "html", size: 0 },
+    ],
+  },
 };
+
+// Storefront SKUs are one purchasable line per bundle, but several bundles reuse the same
+// underlying asset manifest (e.g. the live Shopify catalog sells "BSP-OID-*" SKUs while this
+// manifest was originally keyed by the internal "OID-*-001" naming). Alias them here instead of
+// duplicating manifests, so a rename on either side only needs one line changed.
+SKU_ASSETS["BSP-OID-INTEGRATION-BLUEPRINT"] = SKU_ASSETS["OID-STARTER-001"];
+SKU_ASSETS["BSP-OID-REGISTRY-PLATFORM"] = SKU_ASSETS["OID-DEV-001"];
+SKU_ASSETS["BSP-OID-NPHIES-BUNDLE"] = SKU_ASSETS["OID-HLTH-001"];
+SKU_ASSETS["BSP-OID-ENTERPRISE-BADGE"] = SKU_ASSETS["OID-BADGE-001"];
 
 async function generateLicenseKey(secret, orderId, lineItemId, unit, sku) {
   const prefix = sku.replace(/[^A-Z0-9]/g, "").slice(0, 8);
@@ -229,7 +246,7 @@ async function handleOrderPaid(request, env) {
 
   for (const [lineIndex, lineItem] of (order.line_items || []).entries()) {
     const sku = lineItem.sku;
-    if (!sku || !sku.startsWith("OID-")) {
+    if (!sku || !(sku.startsWith("OID-") || sku.startsWith("BSP-OID-"))) {
       ignored += 1;
       continue;
     }


### PR DESCRIPTION
## Problem
Audit of the store.brainsait.org / OID product launch found that 5 of the 9 live Shopify products (SKUs `BSP-OID-INTEGRATION-BLUEPRINT`, `BSP-OID-REGISTRY-PLATFORM`, `BSP-OID-NPHIES-BUNDLE`, `BSP-OID-ENTERPRISE-BADGE`, `BSP-OID-ARDUINO-SCANNER`) were invisible to `oid-order-fulfillment`'s `SKU_ASSETS` map, which only recognized `OID-*-001` keys. The webhook handler's `sku.startsWith("OID-")` ignore-check silently dropped these line items -- no license, no error, no trace.

## Fix
- Alias the 4 content-matching `BSP-OID-*` SKUs onto their existing manifests (Blueprint -> starter kit, Registry Platform -> developer suite, NPHIES Bundle -> healthcare bundle, Enterprise Badge -> badge system).
- Widen the ignore-check to accept both `OID-` and `BSP-OID-` prefixes.
- Add a manifest entry for `BSP-OID-ARDUINO-SCANNER` (previously unmapped anywhere) pointing at a real uploaded delivery-confirmation asset, since no hardware-guide content exists yet for that product.

## Also fixed as part of this audit (outside this diff)
- Uploaded real product assets for all 9 products to R2 (`brainsait-assets`) -- the bucket was previously empty.
- Registering the missing Shopify `orders/paid` webhook (there were zero webhook subscriptions before this).

`npm test` passes (2/2, including the existing HMAC-rejection and idempotent-replay tests).