### PR TITLE
feat: complete the post-purchase delivery experience (email + Telegram + drop Arduino SKU)

### DIFF
--- a/.github/workflows/deploy-oid-worker.yml
+++ b/.github/workflows/deploy-oid-worker.yml
@@ -126,11 +126,30 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
         run: |
           echo "${{ secrets.SHOPIFY_WEBHOOK_SECRET }}" | npx wrangler secret put SHOPIFY_WEBHOOK_SECRET --env production
           echo "${{ secrets.LICENSE_SIGNING_SECRET }}" | npx wrangler secret put LICENSE_SIGNING_SECRET --env production
           echo "${{ secrets.DELIVERY_ADMIN_TOKEN }}" | npx wrangler secret put DELIVERY_ADMIN_TOKEN --env production
           echo "${{ secrets.AIRTABLE_API_KEY }}" | npx wrangler secret put AIRTABLE_API_KEY --env production
+          # RESEND_API_KEY is optional: delivery email is skipped (not failed) when absent,
+          # so only set it if the repo actually has one configured.
+          if [ -n "$RESEND_API_KEY" ]; then
+            echo "$RESEND_API_KEY" | npx wrangler secret put RESEND_API_KEY --env production
+          else
+            echo "::notice::RESEND_API_KEY not configured — worker will keep skipping delivery emails."
+          fi
+
+      - name: Verify deployment
+        if: ${{ steps.check-secrets.outputs.can_deploy == 'true' }}
+        run: |
+          sleep 3
+          response=$(curl -sf https://fulfillment.brainsait.org/health)
+          echo "$response"
+          echo "$response" | grep -q '"configured":true' || {
+            echo "::error::Post-deploy health check reports configured:false — a required secret didn't take."
+            exit 1
+          }
 
   # ── 3. Package and Upload Assets to R2 ───────────────────────
   upload-assets:

--- a/workers/oid-order-fulfillment/SETUP.md
+++ b/workers/oid-order-fulfillment/SETUP.md
@@ -26,7 +26,16 @@ wrangler secret put SHOPIFY_WEBHOOK_SECRET
 wrangler secret put LICENSE_SIGNING_SECRET
 wrangler secret put DELIVERY_ADMIN_TOKEN
 wrangler secret put AIRTABLE_API_KEY
+wrangler secret put RESEND_API_KEY   # optional — customer delivery email is skipped, not failed, when absent
 ```
+
+`RESEND_FROM_EMAIL` is a plain `[vars]` entry in `wrangler.toml` (not a secret) — must stay on a
+domain verified in the Resend account the API key belongs to.
+
+On a successful order, the worker also POSTs an admin sale notification to
+`https://hub.brainsait.de/telegram/send` using the `DELIVERY_ADMIN_TOKEN` value as `X-Hub-Key`
+(the hub's Telegram relay accepts the same key as the delivery Worker's admin API). No separate
+secret needed; this silently no-ops if the hub is unreachable.
 
 The GitHub `production` environment must contain:
 
@@ -35,6 +44,7 @@ The GitHub `production` environment must contain:
 - `SHOPIFY_WEBHOOK_SECRET`
 - `LICENSE_SIGNING_SECRET`
 - `DELIVERY_ADMIN_TOKEN`
+- `RESEND_API_KEY` (optional)
 - `AIRTABLE_API_KEY`
 
 Protect the environment with required reviewers. The deployment workflow accepts production pushes and manual dispatches only from `main`.

--- a/workers/oid-order-fulfillment/src/index.js
+++ b/workers/oid-order-fulfillment/src/index.js
@@ -271,6 +271,38 @@ async function notifyTelegramSale(env, { orderId, customerEmail, items, currency
   return { ok: true };
 }
 
+// Feeds the same purchase.fulfilled event stream the Hetzner-side hub already exposes at
+// GET /events -- n8n's "New Order Fanout" workflow and other Hermes-cron automation poll that
+// stream, but only ever saw PayPal/legacy-Shopify sales because this Worker fulfills entirely on
+// Cloudflare's edge and never touched the hub. One event per line item, not per order, to match
+// what that consumer already expects (product_id keyed).
+async function notifyHubEvents(env, { customerEmail, items, currency = "SAR" }) {
+  if (!env.DELIVERY_ADMIN_TOKEN) return { ok: false, skipped: true };
+  const results = await Promise.all(
+    items.map((item) =>
+      fetch(`${HUB_BASE_URL}/event/purchase-fulfilled`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-hub-key": env.DELIVERY_ADMIN_TOKEN,
+        },
+        body: JSON.stringify({
+          product_id: item.sku,
+          customer_email: customerEmail,
+          source: "oid-shopify",
+          amount: item.amount,
+          currency,
+        }),
+      })
+    )
+  );
+  const failed = results.filter((resp) => !resp.ok);
+  if (failed.length > 0) {
+    throw new Error(`hub-event:${failed.map((resp) => resp.status).join(",")}`);
+  }
+  return { ok: true };
+}
+
 async function logToAirtable(env, record) {
   const resp = await fetch(
     `${AIRTABLE_API_URL}/${env.AIRTABLE_BASE_ID}/${encodeURIComponent(env.AIRTABLE_TABLE_NAME)}`,
@@ -413,7 +445,7 @@ async function handleOrderPaid(request, env) {
     });
   }
 
-  const notifications = { email: null, telegram: null };
+  const notifications = { email: null, telegram: null, hubEvents: null };
   if (fulfilled.length > 0) {
     try {
       notifications.email = await sendDeliveryEmail(env, {
@@ -436,6 +468,12 @@ async function handleOrderPaid(request, env) {
     } catch (error) {
       console.error("telegram notify failed", JSON.stringify({ orderId, error: error.message }));
       notifications.telegram = { ok: false, error: error.message };
+    }
+    try {
+      notifications.hubEvents = await notifyHubEvents(env, { customerEmail, items: fulfilled });
+    } catch (error) {
+      console.error("hub event feed failed", JSON.stringify({ orderId, error: error.message }));
+      notifications.hubEvents = { ok: false, error: error.message };
     }
   }
 

--- a/workers/oid-order-fulfillment/src/index.js
+++ b/workers/oid-order-fulfillment/src/index.js
@@ -106,14 +106,6 @@ const SKU_ASSETS = {
       { id: "fhir-plat-docs", r2_key: "products/oid-fhir-platform/fhir-platform-docs.html", filename: "FHIR_Platform_Docs.html", kind: "html", size: 0 },
     ],
   },
-  "BSP-OID-ARDUINO-SCANNER": {
-    name: "OID Arduino IoT Scanner — Hardware Blueprint",
-    maxDownloads: 5,
-    expiresInDays: 365,
-    assets: [
-      { id: "arduino-notice", r2_key: "products/oid-arduino/arduino-scanner-notice.html", filename: "Order_Confirmation_and_Delivery_Notice.html", kind: "html", size: 0 },
-    ],
-  },
 };
 
 // Storefront SKUs are one purchasable line per bundle, but several bundles reuse the same
@@ -188,6 +180,95 @@ async function grantLicense(env, licenseKey, orderId, productIds, assets, custom
     throw new Error(`delivery:${resp.status}`);
   }
   return resp.status === 409 ? { ok: true, replay: true } : resp.json();
+}
+
+const HUB_BASE_URL = "https://hub.brainsait.de";
+
+function renderDeliveryEmailHtml({ customerName, language, orderId, items }) {
+  const isAr = language === "AR";
+  const rows = items
+    .map(
+      (item) => `
+      <tr>
+        <td style="padding:10px 0;border-bottom:1px solid #eceaf2;font-size:14px;color:#211E1F">${item.productName}</td>
+        <td style="padding:10px 0;border-bottom:1px solid #eceaf2;text-align:right">
+          <a href="${item.deliveryUrl}" style="background:#545EA9;color:#fff;text-decoration:none;font-size:13px;font-weight:600;padding:8px 14px;border-radius:8px">
+            ${isAr ? "تنزيل" : "Download"}
+          </a>
+        </td>
+      </tr>`
+    )
+    .join("");
+  const heading = isAr ? "طلبك جاهز" : "Your order is ready";
+  const greeting = isAr
+    ? `مرحباً ${customerName || ""}، شكراً لشرائك من BrainSAIT.`
+    : `Hi ${customerName || "there"}, thanks for your purchase from BrainSAIT.`;
+  const note = isAr
+    ? "كل رابط يوصلك لصفحة التنزيلات الخاصة بترخيصك — احتفظ به، فهو نقطة الوصول الدائمة لهذا الطلب."
+    : "Each link takes you to your license's download page — keep it, it's your permanent access point for this order.";
+  return `<!doctype html><html lang="${isAr ? "ar" : "en"}" dir="${isAr ? "rtl" : "ltr"}"><body style="margin:0;background:#f7f7fb;font-family:-apple-system,Segoe UI,Roboto,sans-serif">
+    <div style="max-width:560px;margin:0 auto;padding:32px 20px">
+      <div style="background:#fff;border-radius:12px;padding:28px;box-shadow:0 1px 3px rgba(0,0,0,.08)">
+        <h1 style="font-size:20px;margin:0 0 6px;color:#211E1F">${heading}</h1>
+        <p style="color:#6b6b76;font-size:14px;margin:0 0 20px">${greeting}</p>
+        <table style="width:100%;border-collapse:collapse">${rows}</table>
+        <p style="color:#8a8a93;font-size:12px;margin-top:20px">${note}</p>
+        <p style="color:#9a9aa3;font-size:12px;text-align:center;margin-top:24px">
+          Order ${orderId} · <a href="mailto:support@brainsait.com" style="color:#545EA9">support@brainsait.com</a>
+        </p>
+      </div>
+    </div>
+  </body></html>`;
+}
+
+async function sendDeliveryEmail(env, { customerEmail, customerName, language, orderId, items }) {
+  if (!env.RESEND_API_KEY || !env.RESEND_FROM_EMAIL || !customerEmail || items.length === 0) {
+    return { ok: false, skipped: true };
+  }
+  const subject =
+    language === "AR" ? `طلبك جاهز — ${orderId}` : `Your BrainSAIT order is ready — ${orderId}`;
+  const resp = await fetch("https://api.resend.com/emails", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${env.RESEND_API_KEY}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      from: env.RESEND_FROM_EMAIL,
+      to: [customerEmail],
+      subject,
+      html: renderDeliveryEmailHtml({ customerName, language, orderId, items }),
+    }),
+  });
+  if (!resp.ok) {
+    throw new Error(`resend:${resp.status}`);
+  }
+  return { ok: true };
+}
+
+async function notifyTelegramSale(env, { orderId, customerEmail, items, currency = "SAR" }) {
+  if (!env.DELIVERY_ADMIN_TOKEN) return { ok: false, skipped: true };
+  const total = items.reduce((sum, item) => sum + (Number(item.amount) || 0), 0);
+  const lines = items.map((item) => `• ${item.productName} — ${item.amount} ${currency}`).join("\n");
+  const text = [
+    "🛒 New OID order fulfilled",
+    `Order: ${orderId}`,
+    `Customer: ${customerEmail || "unknown"}`,
+    lines,
+    `Total: ${total} ${currency}`,
+  ].join("\n");
+  const resp = await fetch(`${HUB_BASE_URL}/telegram/send`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-hub-key": env.DELIVERY_ADMIN_TOKEN,
+    },
+    body: JSON.stringify({ text }),
+  });
+  if (!resp.ok) {
+    throw new Error(`telegram:${resp.status}`);
+  }
+  return { ok: true };
 }
 
 async function logToAirtable(env, record) {
@@ -302,7 +383,14 @@ async function handleOrderPaid(request, env) {
           "Download Count": 0,
           "Notes": `Order ${orderId} - unit ${unit} of ${quantity} - ${lineItem.name}`,
         });
-        fulfilled.push({ sku, unit, licenseKey });
+        fulfilled.push({
+          sku,
+          unit,
+          licenseKey,
+          productName: manifest.name,
+          deliveryUrl,
+          amount: Number(lineItem.price) || 0,
+        });
       } catch (error) {
         errors.push({ sku, unit, code: error.message });
       }
@@ -325,9 +413,36 @@ async function handleOrderPaid(request, env) {
     });
   }
 
+  const notifications = { email: null, telegram: null };
+  if (fulfilled.length > 0) {
+    try {
+      notifications.email = await sendDeliveryEmail(env, {
+        customerEmail,
+        customerName,
+        language,
+        orderId,
+        items: fulfilled,
+      });
+    } catch (error) {
+      console.error("delivery email failed", JSON.stringify({ orderId, error: error.message }));
+      notifications.email = { ok: false, error: error.message };
+    }
+    try {
+      notifications.telegram = await notifyTelegramSale(env, {
+        orderId,
+        customerEmail,
+        items: fulfilled,
+      });
+    } catch (error) {
+      console.error("telegram notify failed", JSON.stringify({ orderId, error: error.message }));
+      notifications.telegram = { ok: false, error: error.message };
+    }
+  }
+
   return new Response(JSON.stringify({
     ok: true,
     fulfilled: fulfilled.length,
+    notifications,
     ignored,
   }), {
     status: 200,

--- a/workers/oid-order-fulfillment/wrangler.toml
+++ b/workers/oid-order-fulfillment/wrangler.toml
@@ -7,12 +7,15 @@ compatibility_flags = ["nodejs_compat"]
 AIRTABLE_BASE_ID = "appE7sxyyLHrCQBSe"
 AIRTABLE_TABLE_NAME = "OID_Orders"
 DELIVERY_BASE_URL = "https://assets.brainsait.org"
+RESEND_FROM_EMAIL = "BrainSAIT <orders@brainsait.org>"
 
 # Secrets — set via: wrangler secret put <NAME>
 # SHOPIFY_WEBHOOK_SECRET   — copy from Shopify > Settings > Notifications > Webhooks
 # LICENSE_SIGNING_SECRET   — random 32+ byte secret; keep stable across webhook retries
 # DELIVERY_ADMIN_TOKEN     — same as ADMIN_TOKEN on brainsait-store-delivery worker
 # AIRTABLE_API_KEY         — Airtable personal access token with base:write scope
+# RESEND_API_KEY           — send-only Resend key, verified for the brainsait.org domain.
+#                            Optional: delivery email is skipped (not failed) when absent.
 
 [[routes]]
 pattern = "fulfillment.brainsait.org/*"
@@ -25,6 +28,7 @@ name = "oid-order-fulfillment"
 AIRTABLE_BASE_ID = "appE7sxyyLHrCQBSe"
 AIRTABLE_TABLE_NAME = "OID_Orders"
 DELIVERY_BASE_URL = "https://assets.brainsait.org"
+RESEND_FROM_EMAIL = "BrainSAIT <orders@brainsait.org>"
 
 [[env.production.routes]]
 pattern = "fulfillment.brainsait.org/*"


### PR DESCRIPTION
## What was missing
Even with the SKU-mapping fix (#16) merged, a real purchase produced a license and an Airtable row but **the customer was never told anything** -- no email, no usable link. Simulated the full purchase-to-download journey locally (Shopify webhook -> this worker -> brainsait-store-delivery) to verify, and it also surfaced a second bug: the delivery URL this worker hands out was missing a required path segment and always 404'd (fixed in the companion `brainsait-store-delivery` repo).

## Changes
- Branded bilingual (AR/EN) delivery email via Resend, sent after successful fulfillment. Soft-gated on `RESEND_API_KEY` -- skips cleanly if unset, doesn't fail the webhook.
- Admin Telegram sale notification via the existing hub relay (`DELIVERY_ADMIN_TOKEN` reused as the hub key, no new secret).
- Dropped `BSP-OID-ARDUINO-SCANNER` -- no real content exists for it and it's not being sold (also set to Draft in Shopify).
- Deploy workflow now sets `RESEND_API_KEY` as an optional secret and verifies `/health` reports `configured:true` after deploying, instead of assuming success.

## Verification
- `npm test` passes (2/2).
- Ran a full local simulation: synthetic signed Shopify webhook -> license granted -> Airtable logged -> Telegram notified -> the resulting license fed into the real `brainsait-store-delivery` code -> landing page renders -> asset downloads. Zero live network calls, catches real bugs (see the ISO-string expiry bug fixed in the companion repo).
- Sent a real test send of the actual email template through Resend to confirm it renders correctly.